### PR TITLE
Fix package structure and timeout parsing

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,3 +1,0 @@
-from mcp_jina_reader import serve
-
-serve()

--- a/mcp_jina_reader/__init__.py
+++ b/mcp_jina_reader/__init__.py
@@ -1,4 +1,4 @@
-from mcp_jina_reader import serve
+from .main import serve
 
 
 def main():

--- a/mcp_jina_reader/__main__.py
+++ b/mcp_jina_reader/__main__.py
@@ -1,0 +1,3 @@
+from .main import serve
+
+serve()

--- a/mcp_jina_reader/main.py
+++ b/mcp_jina_reader/main.py
@@ -13,7 +13,8 @@ JINA_SEARCH_ENDPOINT = "https://s.jina.ai/"
 JINA_READ_PREFIX = "https://r.jina.ai/"
 
 api_key = os.getenv("JINA_API_KEY")
-timeout = os.getenv("JINA_TIMEOUT", 10)
+# Ensure timeout is an integer to avoid httpx errors
+timeout = int(os.getenv("JINA_TIMEOUT", "10"))
 
 
 class JinaTools(str, Enum):


### PR DESCRIPTION
## Summary
- move source files into package directory
- fix imports in `__init__` and `__main__`
- ensure timeout env variable is parsed as integer

## Testing
- `python -m py_compile mcp_jina_reader/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ba9eb708832da35da0917c63a28a